### PR TITLE
Submission Flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
           CI_DB_PASS: ${{ secrets.CI_DB_PASS }}
           CI_DB_USER: ${{ secrets.CI_DB_USER }}
           UUID_NAMESPACE: ${{ secrets.UUID_NAMESPACE }}
-        run: deno test -c tsconfig.json --allow-read --allow-net --allow-write --allow-env --unstable __tests__/
+        run: deno test -c tsconfig.json --allow-read --allow-net --allow-write --allow-env --unstable __tests__/index.test.ts

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 web: deno run --allow-net --allow-env --allow-read --unstable -c ./tsconfig.json src/mod.ts start
-test: cross-env DENO_ENV=testing deno test --allow-net --allow-env --allow-read --unstable -c ./tsconfig.json __tests__/
+test: cross-env DENO_ENV=testing deno test --allow-net --allow-env --allow-read --unstable -c ./tsconfig.json __tests__/index.test.ts
 dev: yarn reset && deno run --allow-net --allow-env --allow-read --unstable -c ./tsconfig.json src/mod.ts start
 format: deno fmt --ignore=./node_modules/
 lint: deno lint --ignore=./node_modules/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,32 @@ This is a refactor of the existing Story Squad API built in Deno.
 
 ## Running the Server Locally
 
+There are three options for running the server.
+
+### Option 1: `Denon`
+
+I highly recommend using Denon. It offers two main functionalities that many developers have grown accustomed to from Node development: a file watcher and a script manager. Denon allows you to specify scripts to run in a similar fashion to a Node `package.json` file. Check out the scripts for this project in [`scripts.config.ts`](./scripts.config.ts).
+
+There are two steps to install Denon as a global Bash script:
+
+```bash
+# Step 1: Install from deno.land or nest.land
+deno install -qAf --unstable https://deno.land/x/denon/denon.ts
+# or
+deno install -qAf --unstable https://x.nest.land/denon/denon.ts
+
+# Step 2: Add the denon alias to your Bash config
+echo 'alias denon="~/.deno/bin/denon.cmd"' >> ~/.bashrc
+```
+
+### Option 3: Running Deno Directly
+
+If you don't want the overhead of installing a script runner, you can always run the server with Deno's built-in run script.
+
+```bash
+deno run --allow-net --allow-env --allow-read --unstable -c ./tsconfig.json src/mod.ts start
+```
+
 I recommend installing the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) to run the server locally. It allows you to use the `Procfile` script to run the server with a simple bash command: `heroku local web`.
 
 If you don't want to install the CLI for whatever reason, you can instead just use the `web` script from the `Procfile` directly in your bash terminal:

--- a/__tests__/000.setup.test.ts
+++ b/__tests__/000.setup.test.ts
@@ -41,6 +41,7 @@ export interface IMainSuiteContext {
   db: PostgresAdapter;
   token: string;
 }
+
 export const MainSuite = new TestSuite<IMainSuiteContext>({
   name: '->',
   context: { app, db },

--- a/__tests__/000.setup.test.ts
+++ b/__tests__/000.setup.test.ts
@@ -39,6 +39,7 @@ try {
 export interface IMainSuiteContext {
   app: SuperDeno;
   db: PostgresAdapter;
+  token: string;
 }
 export const MainSuite = new TestSuite<IMainSuiteContext>({
   name: '->',

--- a/__tests__/003.submissions.test.ts
+++ b/__tests__/003.submissions.test.ts
@@ -1,14 +1,10 @@
 import {
   test,
   TestSuite,
-  assertExists,
   assertEquals,
-  assertObjectMatch,
-  assertArrayIncludes,
   assertStringIncludes,
-  DatabaseResult,
 } from '../testDeps.ts';
-import { MainSuite, IMainSuiteContext } from './000.setup.test.ts';
+import { MainSuite } from './000.setup.test.ts';
 import _enum from './testData/enum.ts';
 import submissions from './testData/submissions.ts';
 import users from './testData/users.ts';

--- a/__tests__/003.submissions.test.ts
+++ b/__tests__/003.submissions.test.ts
@@ -1,0 +1,104 @@
+import {
+  test,
+  TestSuite,
+  assertExists,
+  assertEquals,
+  assertObjectMatch,
+  assertArrayIncludes,
+  assertStringIncludes,
+  DatabaseResult,
+} from '../testDeps.ts';
+import { MainSuite, IMainSuiteContext } from './000.setup.test.ts';
+import _enum from './testData/enum.ts';
+import submissions from './testData/submissions.ts';
+import users from './testData/users.ts';
+
+const SubSuite = new TestSuite({
+  name: '/contest/submit',
+  suite: MainSuite,
+  beforeAll: async (context) => {
+    const res = await context.app.post('/auth/login').send({
+      email: users.valid[0].email,
+      password: users.newPass,
+    });
+    context.token = res.body.token;
+
+    await context.db.table('prompts').insert(_enum.prompts).execute();
+  },
+});
+
+const UploadSubSuite = new TestSuite({
+  name: '-> POST',
+  suite: SubSuite,
+});
+
+test(UploadSubSuite, 'returns a 401 on missing token', async (context) => {
+  const res = await context.app.post('/contest/submit');
+  assertEquals(res.status, 401);
+  assertEquals(res.body.message, 'You must be logged in');
+});
+
+test(UploadSubSuite, 'returns a 400 on empty body', async (context) => {
+  const res = await context.app
+    .post('/contest/submit')
+    .set('Authorization', context.token);
+
+  assertEquals(res.status, 400);
+  assertStringIncludes(res.body.message, 'story, promptId');
+});
+
+test(
+  UploadSubSuite,
+  'should return 400 on invalid file field name',
+  async (context) => {
+    const res = await context.app
+      .post('/contest/submit')
+      .set('Authorization', context.token)
+      .send(submissions.invalidField);
+
+    assertEquals(res.status, 400);
+    assertStringIncludes(res.body.message, ': story');
+  }
+);
+
+test(
+  UploadSubSuite,
+  'should return 422 on invalid file type',
+  async (context) => {
+    const res = await context.app
+      .post('/contest/submit')
+      .set('Authorization', context.token)
+      .send(submissions.invalidFile);
+
+    assertEquals(res.status, 422);
+    assertEquals(res.body.message, 'Unsupported file type');
+  }
+);
+
+test(
+  UploadSubSuite,
+  'should return 409 on invalid prompt id',
+  async (context) => {
+    const res = await context.app
+      .post('/contest/submit')
+      .set('Authorization', context.token)
+      .send(submissions.invalidPrompt);
+
+    assertEquals(res.status, 409);
+    assertStringIncludes(res.body.message, 'not found');
+  }
+);
+
+test(
+  UploadSubSuite,
+  'returns a 201 on successful jpeg upload',
+  async (context) => {
+    const res = await context.app
+      .post('/contest/submit')
+      .set('Authorization', context.token)
+      .send(submissions.validFile);
+
+    assertEquals(res.status, 201);
+    assertStringIncludes(res.body.message, 'Upload successful!');
+  }
+);

--- a/__tests__/004.adminContest.test.ts
+++ b/__tests__/004.adminContest.test.ts
@@ -3,7 +3,6 @@ import {
   TestSuite,
   assertEquals,
   assertStringIncludes,
-  assertExists,
   DatabaseResult,
 } from '../testDeps.ts';
 import { IMainSuiteContext, MainSuite } from './000.setup.test.ts';
@@ -118,6 +117,15 @@ test(AdminPostFlags, 'adds a flag to subId 2', async (context) => {
 
   assertEquals(res.status, 201);
   assertEquals(res.body.message, 'Successfully flagged submission');
+});
+
+test(AdminPostFlags, 'returns a 409 on duplicate flag', async (context) => {
+  const res = await context.app
+    .post('/contest/admin/flags?submissionId=2')
+    .send({ flags: [1] });
+
+  assertEquals(res.status, 409);
+  assertEquals(res.body.message, 'Could not create duplicate');
 });
 
 const AdminGetFlags = new TestSuite({

--- a/__tests__/004.adminContest.test.ts
+++ b/__tests__/004.adminContest.test.ts
@@ -1,0 +1,134 @@
+import {
+  test,
+  TestSuite,
+  assertEquals,
+  assertStringIncludes,
+  assertExists,
+  DatabaseResult,
+} from '../testDeps.ts';
+import { IMainSuiteContext, MainSuite } from './000.setup.test.ts';
+import enumItems from './testData/enum.ts';
+
+const AdminContest = new TestSuite({
+  name: '/contest/admin',
+  suite: MainSuite,
+});
+
+const AdminContestGetSubs = new TestSuite({
+  name: '/top -> GET',
+  suite: AdminContest,
+});
+
+test(AdminContestGetSubs, 'returns a list of submissions', async (context) => {
+  const res = await context.app.get('/contest/admin/top');
+
+  assertEquals(res.status, 200);
+  assertEquals(res.body.length, 3);
+});
+
+const AdminPostTop3 = new TestSuite<
+  IMainSuiteContext & { top10: DatabaseResult[] }
+>({
+  name: '/top -> POST',
+  suite: AdminContest,
+  beforeAll: async (context) => {
+    const res = await context.app.get('/contest/admin/top');
+    context.top10 = res.body;
+  },
+});
+
+test(AdminPostTop3, 'returns a 400 on empty body', async (context) => {
+  const res = await context.app.post('/contest/admin/top');
+
+  assertEquals(res.status, 400);
+  assertStringIncludes(res.body.message, 'ids');
+});
+
+test(AdminPostTop3, 'returns a 400 with less than 3 subs', async (context) => {
+  const res = await context.app
+    .post('/contest/admin/top')
+    .send({ ids: [2, 3] });
+
+  assertEquals(res.status, 400);
+  assertStringIncludes(res.body.message, 'ids');
+});
+
+test(AdminPostTop3, 'returns a 400 with more than 3 subs', async (context) => {
+  const res = await context.app
+    .post('/contest/admin/top')
+    .send({ ids: [2, 3, 4, 5] });
+
+  assertEquals(res.status, 400);
+  assertStringIncludes(res.body.message, 'ids');
+});
+
+test(AdminPostTop3, 'throw a 409 on invalid subIds', async (context) => {
+  const res = await context.app
+    .post('/contest/admin/top')
+    .send({ ids: [2, 8, 10] });
+
+  assertEquals(res.status, 409);
+  assertEquals(res.body.message, 'Invalid foreign key');
+});
+
+test(AdminPostTop3, 'returns a 201 on success', async (context) => {
+  const res = await context.app
+    .post('/contest/admin/top')
+    .send({ ids: context.top10.map((x) => x.id).slice(0, 3) });
+
+  assertEquals(res.status, 201);
+  assertEquals(res.body.message, 'Top 3 successfully set!');
+  assertEquals(res.body.top3.length, 3);
+});
+
+const AdminPostFlags = new TestSuite({
+  name: '/flags -> POST',
+  suite: AdminContest,
+  beforeAll: async (context) => {
+    await context.db.table('enum_flags').insert(enumItems.flags).execute();
+  },
+});
+
+test(
+  AdminPostFlags,
+  'returns a 409 on invalid submissionId',
+  async (context) => {
+    const res = await context.app
+      .post('/contest/admin/flags?submissionId=20')
+      .send({ flags: [1] });
+
+    assertEquals(res.status, 409);
+    assertEquals(res.body.message, 'Invalid foreign key');
+  }
+);
+
+test(AdminPostFlags, 'returns a 404 on invalid flagId', async (context) => {
+  const res = await context.app
+    .post('/contest/admin/flags?submissionId=2')
+    .send({ flags: [20] });
+
+  assertEquals(res.status, 409);
+  assertEquals(res.body.message, 'Invalid foreign key');
+});
+
+test(AdminPostFlags, 'adds a flag to subId 2', async (context) => {
+  const res = await context.app
+    .post('/contest/admin/flags?submissionId=2')
+    .send({ flags: [1] });
+
+  assertEquals(res.status, 201);
+  assertEquals(res.body.message, 'Successfully flagged submission');
+});
+
+const AdminGetFlags = new TestSuite({
+  name: '/flags -> GET',
+  suite: AdminContest,
+});
+
+test(AdminGetFlags, 'returns a 201 with a list of flags', async (context) => {
+  const res = await context.app.get('/contest/admin/flags?submissionId=2');
+
+  assertEquals(res.status, 200);
+  assertEquals(res.body.message, 'Received flags');
+  assertEquals(res.body.flags.length, 1);
+});

--- a/__tests__/005.contest.test.ts
+++ b/__tests__/005.contest.test.ts
@@ -1,0 +1,14 @@
+import {
+  test,
+  TestSuite,
+  assertEquals,
+  assertStringIncludes,
+  DatabaseResult,
+} from '../testDeps.ts';
+import { IMainSuiteContext, MainSuite } from './000.setup.test.ts';
+import enumItems from './testData/enum.ts';
+
+const ContestSuite = new TestSuite({
+  name: '/contest',
+  suite: MainSuite,
+});

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,0 +1,4 @@
+import './000.setup.test.ts';
+import './001.server.test.ts';
+import './002.auth.test.ts';
+import './003.submissions.test.ts';

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -2,3 +2,4 @@ import './000.setup.test.ts';
 import './001.server.test.ts';
 import './002.auth.test.ts';
 import './003.submissions.test.ts';
+import './004.adminContest.test.ts'

--- a/__tests__/testData/enum.ts
+++ b/__tests__/testData/enum.ts
@@ -1,3 +1,7 @@
 export default {
   roles: [{ role: 'user' }, { role: 'admin' }, { role: 'teacher' }],
+  prompts: [
+    { active: true, prompt: 'Here is a test prompt' },
+    { active: false, prompt: 'Here is another test prompt' },
+  ],
 };

--- a/__tests__/testData/enum.ts
+++ b/__tests__/testData/enum.ts
@@ -4,4 +4,5 @@ export default {
     { active: true, prompt: 'Here is a test prompt' },
     { active: false, prompt: 'Here is another test prompt' },
   ],
+  flags: [{ flag: 'Content' }],
 };

--- a/__tests__/testData/submissions.ts
+++ b/__tests__/testData/submissions.ts
@@ -3,18 +3,44 @@ import { FormFile } from '../../testDeps.ts';
 const validFile: {
   story: FormFile[];
   promptId: string;
-} = {
-  promptId: '1',
-  story: [
-    {
-      content: new Uint8Array(),
-      contentType: 'image/jpeg',
-      filename: 'somefilename',
-      name: 'story',
-      size: 240,
-    },
-  ],
-};
+}[] = [
+  {
+    promptId: '1',
+    story: [
+      {
+        content: new Uint8Array(),
+        contentType: 'image/jpeg',
+        filename: 'somefilename',
+        name: 'story',
+        size: 240,
+      },
+    ],
+  },
+  {
+    promptId: '1',
+    story: [
+      {
+        content: new Uint8Array(),
+        contentType: 'image/png',
+        filename: 'somefilename2',
+        name: 'story',
+        size: 245,
+      },
+    ],
+  },
+  {
+    promptId: '1',
+    story: [
+      {
+        content: new Uint8Array(),
+        contentType: 'image/jpeg',
+        filename: 'somefilename3',
+        name: 'story',
+        size: 250,
+      },
+    ],
+  },
+];
 
 const invalidFile: {
   story: FormFile[];

--- a/__tests__/testData/submissions.ts
+++ b/__tests__/testData/submissions.ts
@@ -1,0 +1,61 @@
+import { FormFile } from '../../testDeps.ts';
+
+const validFile: {
+  story: FormFile[];
+  promptId: string;
+} = {
+  promptId: '1',
+  story: [
+    {
+      content: new Uint8Array(),
+      contentType: 'image/jpeg',
+      filename: 'somefilename',
+      name: 'story',
+      size: 240,
+    },
+  ],
+};
+
+const invalidFile: {
+  story: FormFile[];
+  promptId: string;
+} = {
+  promptId: '1',
+  story: [
+    {
+      content: new Uint8Array(),
+      contentType: 'text/plain',
+      filename: 'somefilename',
+      name: 'story',
+      size: 240,
+    },
+  ],
+};
+
+const invalidField = {
+  promptId: '1',
+  image: [
+    {
+      content: new Uint8Array(),
+      contentType: 'text/plain',
+      filename: 'somefilename',
+      name: 'story',
+      size: 240,
+    },
+  ],
+};
+
+const invalidPrompt = {
+  promptId: '10',
+  story: [
+    {
+      content: new Uint8Array(),
+      contentType: 'image/jpeg',
+      filename: 'somefilename',
+      name: 'story',
+      size: 240,
+    },
+  ],
+};
+
+export default { validFile, invalidField, invalidFile, invalidPrompt };

--- a/__tests__/testData/users.ts
+++ b/__tests__/testData/users.ts
@@ -20,6 +20,15 @@ const valid: INewUser[] = [
     age: 24,
     parentEmail: 'parentEmail2@email.com',
   },
+  {
+    codename: 'TestCodename3',
+    email: 'someemail3@email.com',
+    firstname: 'Firstname3',
+    lastname: 'Lastname3',
+    password: 'somepass123A',
+    age: 12,
+    parentEmail: 'parentEmail3@email.com',
+  },
 ];
 
 const incomplete: Partial<INewUser> = {

--- a/deps.ts
+++ b/deps.ts
@@ -49,7 +49,11 @@ export { config } from 'https://deno.land/x/dotenv@v2.0.0/mod.ts';
 export { S3Bucket } from 'https://deno.land/x/s3@0.3.0/mod.ts';
 export type {
   GetObjectResponse,
+  GetObjectOptions,
   PutObjectResponse,
+  PutObjectOptions,
+  DeleteObjectOptions,
+  DeleteObjectResponse,
 } from 'https://deno.land/x/s3@0.3.0/mod.ts';
 
 // multiparser @v2.0.3

--- a/deps.ts
+++ b/deps.ts
@@ -30,6 +30,7 @@ export {
   isEmail,
   isIn,
   isBool,
+  minNumber,
 } from 'https://deno.land/x/validasaur@v0.15.0/mod.ts';
 export type {
   ValidationRules,

--- a/docs/DBSetup.md
+++ b/docs/DBSetup.md
@@ -2,32 +2,31 @@
 
 Make sure you have Docker installed on your machine, and then run `docker-compose up -d`.
 
-Your databse container should be set up. If there are any error on composition, you'll need to change ports listed in your Docker configuration files, or you can figure out what on your machine is being hosted on ports 5900, 5932, and 5950.
+Your database container should be set up. If there are any error on composition, you'll need to change ports listed in your Docker configuration files, or you can figure out what on your machine is being hosted on the ports we're attempting to us.
 
 To log in to PGAdmin, open [http://localhost:5950](http://localhost:5950) in your browser. Open the `Servers` group. You should see a server called `SS-Deno-BE`. When you attempt to open the server, it will ask you for a password. The password should be defaulted to `docker` unless you've changed any Docker ENV vars.
 
 ## Database Migrations and Seeding
 
-Install the Cotton CLI to run migrations:
+To handle our database migrations, we're using a Node shell around the application. The currently existing database migration tools for Deno have bugged imports and cause crashes on run. Eventually, we'd like to use the but for now we're using Knex.
+
+You should likely be familiar with our Knex setup. There are scripts in place in our [`package.json`](./../package.json) file to handle all of our database operations:
 
 ```bash
-deno install --allow-net --allow-read --allow-write -n cotton https://deno.land/x/cotton@v0.7.5/cli.ts
+yarn latest # Migrate up until the latest point
+
+yarn rollback # Roll back the previous batch of migrations
+
+yarn seed # Run the existing seed files
+
+yarn reset # Great for development, will rollback, migrate, and seed the database
 ```
 
-Add the Cotton cmd script to your bash aliases:
-
-Open your `.bashrc` configuration file
+We also have scripts in place to run operations on the testing database. To run those, simply appeny `:test` to the above scripts:
 
 ```bash
-vim ~/.bashrc
+yarn latest:test
+yarn rollback:test
+yarn seed:test
+yarn reset:test
 ```
-
-Press `i` to enter insert mode.
-
-On a new line, add the following snippet:
-
-```bash
-alias cotton='~/.deno/bin/cotton.cmd'
-```
-
-> This allows you to run Cotton CLI scripts directly from bash just with the `cotton` keyword!

--- a/docs/DenoSetup.md
+++ b/docs/DenoSetup.md
@@ -4,6 +4,8 @@ This guide is for installing Deno in Git Bash on Windows.
 
 ## Install Deno
 
+View the online installation guide [here](https://deno.land/manual/getting_started/installation), or run the following script:
+
 ```bash
 curl -fsSL https://deno.land/x/install/install.sh | sh
 ```
@@ -12,25 +14,31 @@ curl -fsSL https://deno.land/x/install/install.sh | sh
 
 After installation, run the following commands.
 
-> This command will generate a file structure to allow you to add autocompletion for different bash scripts
+This command will generate a file structure to allow you to add autocompletion for different bash scripts
 
 ```bash
 mkdir ~/.etc && mkdir ~/.etc/bash_completion.d
 ```
 
-> This command generates a file for Deno autocompletion
+This command generates a file for Deno autocompletion
 
 ```bash
 deno completions bash > ~/.etc/bash_completion.d/deno.bash
 ```
 
-> This command will create a bash configuration file that allows you to easily add Deno onto your path (giving you the option to run the `deno` command straight from bash) as well as adding the Deno autocomplete scripts to your configuration
+This command adds the newly-generated completions script to your Bash configuration
 
 ```bash
-echo $'export DENO_INSTALL="/$HOME/.deno"\nexport PATH="$DENO_INSTALL/bin:$PATH"\nsource ~/.etc/bash_completion.d/deno.bash' > ~/.bashrc
+echo "source ~/.etc/bash_completion.d/deno.bash" >> ~/.bashrc
 ```
 
-At this point, you will likely have to restart your machine for your bash configuration to take effect.
+This command will create a bash configuration file that allows you to easily add Deno onto your path (giving you the option to run the `deno` command straight from bash) as well as adding Deno to your path.
+
+```bash
+echo 'export PATH="$HOME/.deno/bin:$PATH"' >> ~/.bashrc
+```
+
+At this point, you will likely have to restart your machine or at least your Bash instance for your new configuration to take effect.
 
 ### Test Your Deno Install
 

--- a/scripts.config.ts
+++ b/scripts.config.ts
@@ -1,0 +1,25 @@
+import type { DenonConfig } from 'https://deno.land/x/denon@2.4.6/mod.ts';
+import { config as env } from 'https://deno.land/x/dotenv@v2.0.0/mod.ts';
+
+const config: DenonConfig = {
+  tsconfig: 'tsconfig.json',
+  unstable: true,
+  allow: ['env', 'read', 'net'],
+  env: env(), // Contrary to the documentation this is vital
+  scripts: {
+    start: {
+      cmd: 'deno run src/mod.ts start',
+    },
+    dev: {
+      cmd: 'yarn reset && deno run src/mod.ts start',
+    },
+    test: {
+      cmd: 'deno test __tests__/index.test.ts',
+      env: {
+        DENO_ENV: 'testing', // Set the testing environment
+      },
+    },
+  },
+};
+
+export default config;

--- a/src/api/middlewares/authHandler.ts
+++ b/src/api/middlewares/authHandler.ts
@@ -54,7 +54,7 @@ export default (config?: IAuthHandlerConfig) => async (
         if (adminOnly) {
           logger.debug('Successfully authenticated, checking admin status');
           // Get an instance of the UserModel if we need to admin check
-          const userModelInstance = serviceCollection.get(UserModel);
+          // const userModelInstance = serviceCollection.get(UserModel);
           // If user is not an admin
           // const userIsAdmin = await userModelInstance.checkIsAdmin(id);
           const userIsAdmin = true;
@@ -63,6 +63,7 @@ export default (config?: IAuthHandlerConfig) => async (
           }
         }
         // Pull the relevant snippets and continue
+        req.body.userInfo = {};
         req.body.userInfo.email = email;
         req.body.userInfo.id = id;
         next();

--- a/src/api/middlewares/authHandler.ts
+++ b/src/api/middlewares/authHandler.ts
@@ -13,16 +13,16 @@ import UserModel from '../../models/users.ts';
 /**
  * Defaults to authReuired and adminOnly being true
  */
-export default (config?: IAuthHandlerConfig) => async (
+export default ({
+  adminOnly = true,
+  authRequired = true,
+}: IAuthHandlerConfig) => async (
   req: Request,
   res: Response,
   next: NextFunction
 ) => {
   const logger: log.Logger = serviceCollection.get('logger');
   const token = req.get('Authorization');
-
-  const authRequired = config?.authRequired || true;
-  const adminOnly = config?.adminOnly || true;
 
   if (!token || token === 'null') {
     // If no token, check if auth is even required...

--- a/src/api/middlewares/authHandler.ts
+++ b/src/api/middlewares/authHandler.ts
@@ -69,7 +69,6 @@ export default (config?: IAuthHandlerConfig) => async (
         next();
       }
     } catch (err) {
-      console.log(err);
       logger.error(err);
       throw err;
     }

--- a/src/api/middlewares/authHandler.ts
+++ b/src/api/middlewares/authHandler.ts
@@ -69,6 +69,7 @@ export default (config?: IAuthHandlerConfig) => async (
         next();
       }
     } catch (err) {
+      console.log(err);
       logger.error(err);
       throw err;
     }

--- a/src/api/middlewares/upload.ts
+++ b/src/api/middlewares/upload.ts
@@ -48,6 +48,7 @@ export default (...fileNames: string[]) => async (
 
     next();
   } catch (err) {
+    console.log(err);
     logger.error(err);
     throw err;
   }

--- a/src/api/middlewares/upload.ts
+++ b/src/api/middlewares/upload.ts
@@ -48,7 +48,6 @@ export default (...fileNames: string[]) => async (
 
     next();
   } catch (err) {
-    console.log(err);
     logger.error(err);
     throw err;
   }

--- a/src/api/middlewares/validate.ts
+++ b/src/api/middlewares/validate.ts
@@ -32,6 +32,7 @@ export default <T = undefined>(
       );
     }
   } catch (err) {
+    console.log(err);
     logger.error(err);
     return next(err);
   }

--- a/src/api/middlewares/validate.ts
+++ b/src/api/middlewares/validate.ts
@@ -32,7 +32,6 @@ export default <T = undefined>(
       );
     }
   } catch (err) {
-    console.log(err);
     logger.error(err);
     return next(err);
   }

--- a/src/api/middlewares/validate.ts
+++ b/src/api/middlewares/validate.ts
@@ -28,7 +28,7 @@ export default <T = undefined>(
     } else {
       throw createError(
         400,
-        `Invalid or missing fields: ${errorFields.join(', ')}`
+        `Invalid or missing fields in ${toValidate}: ${errorFields.join(', ')}`
       );
     }
   } catch (err) {

--- a/src/api/routes/contest/adminContest.ts
+++ b/src/api/routes/contest/adminContest.ts
@@ -1,0 +1,90 @@
+import {
+  Router,
+  IRouter,
+  Request,
+  Response,
+  NextFunction,
+  log,
+  serviceCollection,
+  validateArray,
+  validateObject,
+  isString,
+  required,
+  isNumber,
+  minNumber,
+  isIn,
+  isArray,
+} from '../../../../deps.ts';
+import SubmissionModel from '../../../models/submissions.ts';
+import AdminService from '../../../services/admin.ts';
+import authHandler from '../../middlewares/authHandler.ts';
+import validate from '../../middlewares/validate.ts';
+
+const route = Router();
+
+export default (app: IRouter) => {
+  const logger: log.Logger = serviceCollection.get('logger');
+  const adminServiceInstance = serviceCollection.get(AdminService);
+
+  app.use('/admin', route);
+
+  route.get(
+    '/top',
+    authHandler({ adminOnly: false, authRequired: false }),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const submissionModelInstance = serviceCollection.get(SubmissionModel);
+        const top10 = await submissionModelInstance.getTodaysTop10();
+
+        res.setStatus(200).json(top10);
+      } catch (err) {
+        logger.error(err);
+        throw err;
+      }
+    }
+  );
+
+  route.post(
+    '/top',
+    validate({
+      ids: validateArray(true, [minNumber(1)], {
+        minLength: 3,
+        maxLength: 3,
+      }),
+    }),
+    async (req: Request, res: Response, next: NextFunction) => {
+      const top3 = await adminServiceInstance.setTop3(req.body.ids);
+
+      res.setStatus(201).json({ top3, message: 'Top 3 successfully set!' });
+    }
+  );
+
+  route.get(
+    '/flags',
+    validate({ submissionId: [required] }, 'query'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      const flags = await adminServiceInstance.getFlagsBySubId(
+        parseInt(req.query.submissionId)
+      );
+      res.setStatus(200).json({ flags, message: 'Received flags' });
+    }
+  );
+
+  route.post(
+    '/flags',
+    validate({ submissionId: [required] }, 'query'),
+    validate({ flags: [isArray] }, 'body'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      const flags = await adminServiceInstance.flagSubmission(
+        req.query.submissionId,
+        req.body.flags
+      );
+
+      res
+        .setStatus(201)
+        .json({ flags, message: 'Successfully flagged submission' });
+    }
+  );
+
+  console.log('Contest Admin router loaded.');
+};

--- a/src/api/routes/contest/index.ts
+++ b/src/api/routes/contest/index.ts
@@ -1,4 +1,5 @@
 import { IRouter, Router } from '../../../../deps.ts';
+import adminContest from './adminContest.ts';
 import prompts from './prompts.ts';
 import submissions from './submissions.ts';
 
@@ -9,6 +10,7 @@ export default (app: IRouter) => {
 
   submissions(contestRouter);
   prompts(contestRouter);
+  adminContest(contestRouter);
 
   console.log('Contest routers loaded.');
 };

--- a/src/api/routes/contest/submissions.ts
+++ b/src/api/routes/contest/submissions.ts
@@ -64,7 +64,6 @@ export default (app: IRouter) => {
         );
         res.setStatus(201).json({ message: 'Upload successful!' });
       } catch (err) {
-        console.log(err);
         logger.error(err);
         throw err;
       }

--- a/src/api/routes/contest/submissions.ts
+++ b/src/api/routes/contest/submissions.ts
@@ -70,29 +70,5 @@ export default (app: IRouter) => {
     }
   );
 
-  route.get('/', (req: Request, res: Response) => {
-    // I don't know what this one does yet??
-    res.setStatus(200).json({ hit: req.path });
-  });
-
-  route.get(
-    '/:submissionId',
-    (req: Request, res: Response, next: NextFunction) => {
-      // Here is where you get submission data from s3
-      const subServiceInstance = serviceCollection.get(SubmissionService);
-      // const sub = await subServiceInstance.retrieveImage(1);
-      // console.log(sub);
-      res.setStatus(200).json({});
-    }
-  );
-
-  route.post(
-    '/test',
-    upload('field1', 'field2'),
-    (req: Request, res: Response, next: NextFunction) => {
-      res.setStatus(200).json({ hit: 'it' });
-    }
-  );
-
   console.log('Submission router loaded.');
 };

--- a/src/api/routes/contest/submissions.ts
+++ b/src/api/routes/contest/submissions.ts
@@ -38,7 +38,7 @@ export default (app: IRouter) => {
         }),
         { minLength: 1, maxLength: 1 }
       ),
-      promptId: [required, isNumber],
+      promptId: [required, isString],
     }),
     upload('story'),
     // Make sure upload was processed correctly
@@ -57,9 +57,9 @@ export default (app: IRouter) => {
         const submissionModelInstance = serviceCollection.get(
           SubmissionService
         );
-        await submissionModelInstance.sendToDSAndStore(
+        await submissionModelInstance.processSubmission(
           req.body.story[0],
-          req.body.promptId,
+          parseInt(req.body.promptId, 10),
           req.body.userInfo.id
         );
         res.setStatus(201).json({ message: 'Upload successful!' });
@@ -77,12 +77,12 @@ export default (app: IRouter) => {
 
   route.get(
     '/:submissionId',
-    async (req: Request, res: Response, next: NextFunction) => {
+    (req: Request, res: Response, next: NextFunction) => {
       // Here is where you get submission data from s3
       const subServiceInstance = serviceCollection.get(SubmissionService);
-      const sub = await subServiceInstance.retrieveImage(1);
-      console.log(sub);
-      res.setStatus(200).json(sub);
+      // const sub = await subServiceInstance.retrieveImage(1);
+      // console.log(sub);
+      res.setStatus(200).json({});
     }
   );
 

--- a/src/api/routes/contest/submissions.ts
+++ b/src/api/routes/contest/submissions.ts
@@ -64,6 +64,7 @@ export default (app: IRouter) => {
         );
         res.setStatus(201).json({ message: 'Upload successful!' });
       } catch (err) {
+        console.log(err);
         logger.error(err);
         throw err;
       }

--- a/src/db/migrations/20210110194826_submission_flags.js
+++ b/src/db/migrations/20210110194826_submission_flags.js
@@ -14,6 +14,7 @@ exports.up = function (knex) {
       .references('enum_flags.id')
       .onUpdate('CASCADE')
       .onDelete('RESTRICT');
+    t.unique(['submissionId', 'flagId']);
   });
 };
 

--- a/src/interfaces/enumFlags.ts
+++ b/src/interfaces/enumFlags.ts
@@ -6,4 +6,6 @@ export interface INewEnumFlags {
   flag: string;
 }
 
-export enum Flags {}
+export enum Flags {
+  Content = 1,
+}

--- a/src/loaders/bucket.ts
+++ b/src/loaders/bucket.ts
@@ -1,4 +1,13 @@
-import { S3Bucket, v4 } from '../../deps.ts';
+import {
+  DeleteObjectOptions,
+  DeleteObjectResponse,
+  GetObjectOptions,
+  GetObjectResponse,
+  PutObjectOptions,
+  PutObjectResponse,
+  S3Bucket,
+  v4,
+} from '../../deps.ts';
 import env from '../config/env.ts';
 
 export default () => {
@@ -16,7 +25,36 @@ export default () => {
 };
 
 class TestS3Bucket {
-  public upload(buffer: Uint8Array, extension?: string) {
-    return v4.generate();
+  public putObject(
+    key: string,
+    body: Uint8Array,
+    options?: PutObjectOptions | undefined
+  ): PutObjectResponse {
+    return {
+      etag: v4.generate(),
+    };
+  }
+  public deleteObject(
+    key: string,
+    options?: DeleteObjectOptions | undefined
+  ): DeleteObjectResponse {
+    return {
+      deleteMarker: true,
+    };
+  }
+  public getObject(
+    key: string,
+    options?: GetObjectOptions | undefined
+  ): GetObjectResponse {
+    return {
+      body: new Uint8Array(),
+      contentLength: 5,
+      deleteMarker: false,
+      etag: v4.generate(),
+      lastModified: new Date(),
+      missingMeta: 0,
+      storageClass: 'STANDARD',
+      taggingCount: 0,
+    };
   }
 }

--- a/src/loaders/formParser.ts
+++ b/src/loaders/formParser.ts
@@ -17,7 +17,6 @@ export default () => async (
   try {
     const form = await multiParser(req);
     if (!form) return next();
-
     if (form.files) {
       const files: { [key: string]: FormFile[] } = {};
       const fileFieldNames = Object.keys(form.files);

--- a/src/loaders/opine.ts
+++ b/src/loaders/opine.ts
@@ -64,25 +64,9 @@ export default (app: Opine) => {
   app.use((err: IError, req: Request, res: Response, next: NextFunction) => {
     logger.debug(`${err.status} ${err.message}`);
     if (err.message.includes('violates unique constraint')) {
-      const dataName = err.message.match(/_([^_]+)/);
-      return next(
-        createError(
-          409,
-          dataName && dataName[1]
-            ? dataName[1] + ' already in use'
-            : 'Could not create duplicate'
-        )
-      );
+      return next(createError(409, 'Could not create duplicate'));
     } else if (err.message.includes('violates foreign key constraint')) {
-      const dataName = err.message.match(/_([^_]+)/);
-      return next(
-        createError(
-          409,
-          dataName && dataName[1]
-            ? dataName[1] + ' not found'
-            : 'Invalid foreign key'
-        )
-      );
+      return next(createError(409, 'Invalid foreign key'));
     } else if (!err.status || err.status === 500) {
       logger.warning(`${err.message} - NEEDS CUSTOM ERROR HANDLING`);
     }

--- a/src/models/baseModel.ts
+++ b/src/models/baseModel.ts
@@ -27,14 +27,16 @@ export default class BaseModel<T, U> {
   // Putting basic CRUD operations on all Models
 
   // Overloading function call for better linting and usability :)
-  public async add<B extends boolean>(body: T): Promise<U[]>;
+  public async add<B extends boolean>(body: T | T[]): Promise<U[]>;
   public async add<B extends boolean>(
-    body: T,
+    body: T | T[],
     first?: B
   ): Promise<B extends true ? U : U[]>;
-  public async add(body: T & QueryValues, first?: boolean): Promise<U | U[]> {
+  public async add(
+    body: (T & QueryValues) | (T & QueryValues)[],
+    first?: boolean
+  ): Promise<U | U[]> {
     this.logger.debug(`Attempting to add field to table ${this.tableName}`);
-
     const response = ((await this.db
       .table(this.tableName)
       .insert(body)

--- a/src/models/flagModel.ts
+++ b/src/models/flagModel.ts
@@ -1,0 +1,43 @@
+import {
+  Service,
+  serviceCollection,
+  PostgresAdapter,
+  log,
+} from '../../deps.ts';
+
+@Service()
+export default class FlagModel {
+  constructor() {
+    this.db = serviceCollection.get('pg');
+    this.logger = serviceCollection.get('logger');
+  }
+  protected db: PostgresAdapter;
+  protected logger: log.Logger;
+
+  public async getBySubmissionId(id: number) {
+    const flags = ((await this.db
+      .table('submission_flags')
+      .innerJoin('enum_flags', 'enum_flags.id', 'submission_flags.flagId')
+      .select('enum_flags.flag')
+      .where('submission_flags.submissionId', id)
+      .execute()) as unknown) as { flag: string }[];
+
+    return flags;
+  }
+
+  public async addFlagsToSub(
+    flagItems: {
+      submissionId: number;
+      flagId: number;
+    }[]
+  ) {
+    const res = await this.db
+      .table('submission_flags')
+      .insert(flagItems)
+      .returning('*')
+      .execute();
+    return res;
+  }
+}
+
+serviceCollection.addTransient(FlagModel);

--- a/src/models/promptQueue.ts
+++ b/src/models/promptQueue.ts
@@ -2,7 +2,7 @@ import { Service, serviceCollection } from '../../deps.ts';
 import {
   INewPromptQueueItem,
   IPromptQueueItem,
-} from '../interfaces/prompts.ts';
+} from '../interfaces/promptQueue.ts';
 import BaseModel from './baseModel.ts';
 
 @Service()

--- a/src/models/top3Model.ts
+++ b/src/models/top3Model.ts
@@ -1,0 +1,12 @@
+import { Service, serviceCollection } from '../../deps.ts';
+import { INewTop3, ITop3 } from '../interfaces/top3.ts';
+import BaseModel from './baseModel.ts';
+
+@Service()
+export default class Top3Model extends BaseModel<INewTop3, ITop3> {
+  constructor() {
+    super('top3');
+  }
+}
+
+serviceCollection.addTransient(Top3Model);

--- a/src/services/admin.ts
+++ b/src/services/admin.ts
@@ -5,15 +5,20 @@ import {
   serviceCollection,
   createError,
 } from '../../deps.ts';
+import { INewTop3 } from '../interfaces/top3.ts';
+import FlagModel from '../models/flagModel.ts';
 import PromptQueueModel from '../models/promptQueue.ts';
 import PromptModel from '../models/prompts.ts';
+import Top3Model from '../models/top3Model.ts';
 import BaseService from './baseService.ts';
 
 @Service()
 export default class AdminService extends BaseService {
   constructor(
     @Inject(PromptModel) private promptModel: PromptModel,
-    @Inject(PromptQueueModel) private promptQueue: PromptQueueModel
+    @Inject(PromptQueueModel) private promptQueue: PromptQueueModel,
+    @Inject(Top3Model) private top3Model: Top3Model,
+    @Inject(FlagModel) private flagModel: FlagModel
   ) {
     super();
   }
@@ -45,6 +50,39 @@ export default class AdminService extends BaseService {
       this.logger.debug('Successfully updated active prompt');
 
       return newId;
+    } catch (err) {
+      this.logger.error(err);
+      throw err;
+    }
+  }
+
+  public async setTop3(ids: number[]) {
+    try {
+      const formattedTop3: INewTop3[] = ids.map((id) => ({ submissionId: id }));
+      const top3 = await this.top3Model.add(formattedTop3);
+      return top3;
+    } catch (err) {
+      this.logger.error(err);
+      throw err;
+    }
+  }
+
+  public async getFlagsBySubId(submissionId: number) {
+    try {
+      const flags = await this.flagModel.getBySubmissionId(submissionId);
+      const parsedFlags = flags.map((flag) => flag.flag);
+      return parsedFlags;
+    } catch (err) {
+      this.logger.error(err);
+      throw err;
+    }
+  }
+
+  public async flagSubmission(submissionId: number, flagIds: number[]) {
+    try {
+      const flagItems = flagIds.map((flagId) => ({ flagId, submissionId }));
+      const flags = await this.flagModel.addFlagsToSub(flagItems);
+      return flags;
     } catch (err) {
       this.logger.error(err);
       throw err;

--- a/src/services/admin.ts
+++ b/src/services/admin.ts
@@ -1,10 +1,4 @@
-import {
-  Service,
-  Inject,
-  log,
-  serviceCollection,
-  createError,
-} from '../../deps.ts';
+import { Service, Inject, serviceCollection, createError } from '../../deps.ts';
 import { INewTop3 } from '../interfaces/top3.ts';
 import FlagModel from '../models/flagModel.ts';
 import PromptQueueModel from '../models/promptQueue.ts';

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -28,21 +28,28 @@ export default class AuthService extends BaseService {
   }
 
   public async SignUp(body: INewUser) {
+    // Initialize variable to store sendTo email for validation
+    let sendTo: string;
     // Underage users must have a parent email on file for validation
     if (!body.age) {
       throw createError(400, 'No age sent');
     }
-    if (
-      body.age < 13 &&
-      (!body.parentEmail || body.email === body.parentEmail)
-    ) {
-      throw createError(400, 'Underage users must have a parent email on file');
+    if (body.age < 13) {
+      if (!body.parentEmail || body.email === body.parentEmail) {
+        throw createError(
+          400,
+          'Underage users must have a parent email on file'
+        );
+      } else {
+        sendTo = body.parentEmail;
+      }
+    } else {
+      sendTo = body.email;
     }
     try {
       // Start a transaction for data integrity
       await this.db.transaction(async () => {
         // Further sanitize data
-        const sendTo = body.parentEmail || body.email;
         Reflect.deleteProperty(body, 'age');
         Reflect.deleteProperty(body, 'parentEmail');
 

--- a/src/services/bucket.ts
+++ b/src/services/bucket.ts
@@ -73,7 +73,7 @@ export default class BucketService {
   }
 
   private isValidFileType(extension: string) {
-    const allowedExtensions = ['jpg', 'heic', 'png', 'jpeg'];
+    const allowedExtensions = ['jpg', 'png', 'jpeg'];
     // console.log({ extension }, allowedExtensions.includes(extension));
     return allowedExtensions.includes(extension);
   }

--- a/src/services/bucket.ts
+++ b/src/services/bucket.ts
@@ -22,6 +22,8 @@ export default class BucketService {
   ): Promise<IUploadResponse> {
     try {
       if (!extension) throw createError(400, `Could not get file extension`);
+      if (!this.isValidFileType(extension))
+        throw createError(422, 'Unsupported file type');
       const s3Label = new URLSearchParams({
         name: Date.now() + '-' + v4.generate() + '.' + extension,
       }).get('name') as string;
@@ -41,22 +43,39 @@ export default class BucketService {
   }
 
   public async get(name: string, etag: string) {
-    try {
-      this.logger.debug(`Attempting to retrieve bucket item ${name}`);
-      const response = await this.s3.getObject(name, {
-        ifMatch: etag,
-      });
+    this.logger.debug(`Attempting to retrieve bucket item ${name}`);
+    const response = await this.s3.getObject(name, {
+      ifMatch: etag,
+    });
 
-      if (response) {
-        this.logger.debug(`Retrieved ${name} from S3 successfully`);
-        return response;
+    if (response) {
+      this.logger.debug(`Retrieved ${name} from S3 successfully`);
+      return response;
+    } else {
+      throw createError(404, `Could not find ${name} in S3 bucket`);
+    }
+  }
+
+  public async remove(name: string) {
+    try {
+      this.logger.debug(`Attempting to remove ${name} from the bucket`);
+
+      const response = await this.s3.deleteObject(name);
+      if (!response.deleteMarker) {
+        this.logger.critical(`File with name ${name} is untracked`);
       } else {
-        throw createError(404, `Could not find ${name} in S3 bucket`);
+        this.logger.debug(`File ${name} successfully deleted`);
       }
     } catch (err) {
-      this.logger.error(err);
+      this.logger.critical(err);
       throw err;
     }
+  }
+
+  private isValidFileType(extension: string) {
+    const allowedExtensions = ['jpg', 'heic', 'png', 'jpeg'];
+    // console.log({ extension }, allowedExtensions.includes(extension));
+    return allowedExtensions.includes(extension);
   }
 }
 serviceCollection.addTransient(BucketService);

--- a/testDeps.ts
+++ b/testDeps.ts
@@ -16,3 +16,5 @@ export { isFreePort } from 'https://deno.land/x/free_port@v1.2.0/mod.ts';
 export type { DatabaseResult } from 'https://deno.land/x/cotton@v0.7.5/src/adapters/adapter.ts';
 
 export { v5 } from 'https://deno.land/std@0.83.0/uuid/mod.ts';
+
+export type { FormFile } from 'https://deno.land/x/multiparser@v2.0.3/mod.ts';


### PR DESCRIPTION
# Submission Router & Model Work

- Added new test suite for submission endpoints
- Added tests for `POST /contest/submit`
- Added test data for submissions and prompts
- Added conditional that doesn't load form parser in a testing environment
- renamed `sendToDSAndStore` -> `processSubmission`
- Added ability to delete objects from S3 bucket if we upload them and then fail to track them in our database
- Added S3 bucket mock for testing
- Added error handler for foreign key violations
- Added check for filetypes
- Adds tests for submissions and admin tasks
- Adds test data for both
- Adds admin routes
- Adds flag model
- Adds admin service members
- Fixes auth handler
- Fixes auth service age checking