### PR TITLE
Feature/game instances

### DIFF
--- a/src/api/routes/rumble/index.ts
+++ b/src/api/routes/rumble/index.ts
@@ -2,6 +2,7 @@ import { IRouter, Router } from '../../../../deps.ts';
 import rumbleData from './rumbleData.ts';
 import students from './students.ts';
 import teachers from './teachers.ts';
+import sections from './sections.ts';
 
 export default (app: IRouter) => {
   console.log('Loading rumble routers...');
@@ -10,6 +11,7 @@ export default (app: IRouter) => {
 
   teachers(rumbleRouter);
   students(rumbleRouter);
+  sections(rumbleRouter);
   rumbleData(rumbleRouter);
 
   console.log('Rumble routers loaded.');

--- a/src/api/routes/rumble/sections.ts
+++ b/src/api/routes/rumble/sections.ts
@@ -9,13 +9,13 @@ import {
 } from '../../../../deps.ts';
 import { uuidV5Regex } from '../../../config/dataConstraints.ts';
 import validate from '../../middlewares/validate.ts';
-import CleverService from '../../../services/cleverService.ts';
+import RumbleService from '../../../services/rumble.ts';
 
 const route = Router();
 
 export default (app: IRouter) => {
   const logger: log.Logger = serviceCollection.get('logger');
-  const cleverServiceInstance = serviceCollection.get(CleverService);
+  const rumbleServiceInstance = serviceCollection.get(RumbleService);
   app.use('/sections', route);
 
   // POST /:sectionId/students/:studentId - adds a student to a section
@@ -26,7 +26,7 @@ export default (app: IRouter) => {
     }),
     async (req, res) => {
       try {
-        const section = await cleverServiceInstance.addChildToSection(
+        const section = await rumbleServiceInstance.addChildToSection(
           req.body.joinCode,
           parseInt(req.params.sectionId, 10),
           parseInt(req.params.studentId, 10)

--- a/src/api/routes/rumble/sections.ts
+++ b/src/api/routes/rumble/sections.ts
@@ -1,0 +1,44 @@
+import {
+  Router,
+  IRouter,
+  log,
+  serviceCollection,
+  required,
+  isString,
+  match,
+} from '../../../../deps.ts';
+import { uuidV5Regex } from '../../../config/dataConstraints.ts';
+import validate from '../../middlewares/validate.ts';
+import CleverService from '../../../services/cleverService.ts';
+
+const route = Router();
+
+export default (app: IRouter) => {
+  const logger: log.Logger = serviceCollection.get('logger');
+  const cleverServiceInstance = serviceCollection.get(CleverService);
+  app.use('/sections', route);
+
+  // POST /:sectionId/students/:studentId - adds a student to a section
+  route.post(
+    '/:sectionId/students/:studentId',
+    validate({
+      joinCode: [required, isString, match(uuidV5Regex)],
+    }),
+    async (req, res) => {
+      try {
+        const section = await cleverServiceInstance.addChildToSection(
+          req.body.joinCode,
+          parseInt(req.params.sectionId, 10),
+          parseInt(req.params.studentId, 10)
+        );
+
+        res.setStatus(201).json(section);
+      } catch (err) {
+        logger.error(err);
+        throw err;
+      }
+    }
+  );
+
+  console.log('Rumble sections route loaded successfully.');
+};

--- a/src/api/routes/rumble/teachers.ts
+++ b/src/api/routes/rumble/teachers.ts
@@ -84,5 +84,23 @@ export default (app: IRouter) => {
     }
   );
 
+  // PUT /rumbles/:rumbleId/start - begins a game and returns a Date
+  route.put(
+    '/:teacherId/sections/:sectionId/rumbles/:rumbleId/start',
+    authHandler({ roles: [Roles.teacher, Roles.admin] }),
+    async (req, res) => {
+      try {
+        const endTime = await rumbleServiceInstance.startRumble(
+          parseInt(req.params.sectionId, 10),
+          parseInt(req.params.rumbleId, 10)
+        );
+        res.setStatus(201).json(endTime);
+      } catch (err) {
+        logger.error(err);
+        throw err;
+      }
+    }
+  );
+
   console.log('Rumble teacher route loaded.');
 };

--- a/src/db/migrations/20210122113449_rumbles.js
+++ b/src/db/migrations/20210122113449_rumbles.js
@@ -12,6 +12,7 @@ exports.up = function (knex) {
       .references('prompts.id')
       .onUpdate('CASCADE')
       .onDelete('RESTRICT');
+    t.datetime('created_at').defaultTo(knex.raw("(now() at time zone 'utc')"));
   });
 };
 

--- a/src/db/migrations/20210122113747_rumble_sections.js
+++ b/src/db/migrations/20210122113747_rumble_sections.js
@@ -2,7 +2,6 @@
 exports.up = function (knex) {
   return knex.schema.createTable('rumble_sections', (t) => {
     t.increments('id');
-    t.integer('score');
     t.dateTime('endTime').notNullable();
     t.integer('rumbleId')
       .unsigned()
@@ -16,6 +15,7 @@ exports.up = function (knex) {
       .references('clever_sections.id')
       .onUpdate('CASCADE')
       .onDelete('RESTRICT');
+    t.datetime('created_at').defaultTo(knex.raw("(now() at time zone 'utc')"));
   });
 };
 

--- a/src/interfaces/apiResponses.ts
+++ b/src/interfaces/apiResponses.ts
@@ -8,8 +8,13 @@ export interface IAuthResponse {
 }
 
 export interface ICleverEnumData {
-  grades: { gradeId: string; value: string }[];
-  subjects: { subjectId: string; value: string }[];
+  grades: ISelectOption[];
+  subjects: ISelectOption[];
+}
+
+export interface ISelectOption {
+  value: string;
+  label: string;
 }
 
 /**

--- a/src/interfaces/apiResponses.ts
+++ b/src/interfaces/apiResponses.ts
@@ -7,6 +7,11 @@ export interface IAuthResponse {
   token: string;
 }
 
+export interface ICleverEnumData {
+  grades: { gradeId: string; value: string }[];
+  subjects: { subjectId: string; value: string }[];
+}
+
 /**
  * # Clever Auth Response
  *

--- a/src/interfaces/cleverSections.ts
+++ b/src/interfaces/cleverSections.ts
@@ -4,12 +4,15 @@ import { Subjects } from './enumSubjects.ts';
 
 export interface ISection extends INewSection {
   id: number;
-  active: boolean;
 }
 
-export interface INewSection {
-  name: string;
+export interface INewSection extends ISectionPostBody {
+  active: boolean;
   joinCode: string;
+}
+
+export interface ISectionPostBody {
+  name: string;
   subjectId: Subjects | CleverSubjectType;
   gradeId: Grades | CleverGradeType;
 }

--- a/src/interfaces/enumGrades.ts
+++ b/src/interfaces/enumGrades.ts
@@ -3,7 +3,7 @@ export interface IGradeEnum {
   grade: GradeType[keyof GradeType];
 }
 
-type GradeType = {
+export type GradeType = {
   1: '1st';
   2: '2nd';
   3: '3rd';

--- a/src/interfaces/enumSubjects.ts
+++ b/src/interfaces/enumSubjects.ts
@@ -3,7 +3,7 @@ export interface ISubjectEnum {
   subject: SubjectType[keyof SubjectType];
 }
 
-type SubjectType = {
+export type SubjectType = {
   'english/language arts': 'English/Language Arts';
   math: 'Math';
   science: 'Science';

--- a/src/interfaces/rumbleSections.ts
+++ b/src/interfaces/rumbleSections.ts
@@ -1,0 +1,10 @@
+export interface IRumbleSections extends INewRumbleSections {
+  id: number;
+  endTime?: Date;
+  created_at: Date;
+}
+
+export interface INewRumbleSections {
+  rumbleId: number;
+  sectionId: number;
+}

--- a/src/interfaces/rumbles.ts
+++ b/src/interfaces/rumbles.ts
@@ -1,0 +1,15 @@
+export interface IRumble extends INewRumble {
+  id: number;
+  created_at: Date;
+}
+
+export interface INewRumble extends IRumblePostBody {
+  canJoin: boolean;
+  joinCode: string;
+  maxSections: number;
+}
+
+export interface IRumblePostBody {
+  numMinutes: number;
+  promptId: number;
+}

--- a/src/models/rumbleSections.ts
+++ b/src/models/rumbleSections.ts
@@ -1,0 +1,18 @@
+import { Service, serviceCollection } from '../../deps.ts';
+import {
+  INewRumbleSections,
+  IRumbleSections,
+} from '../interfaces/rumbleSections.ts';
+import BaseModel from './baseModel.ts';
+
+@Service()
+export default class RumbleSectionsModel extends BaseModel<
+  INewRumbleSections,
+  IRumbleSections
+> {
+  constructor() {
+    super('rumble_sections');
+  }
+}
+
+serviceCollection.addTransient(RumbleSectionsModel);

--- a/src/models/rumbleSections.ts
+++ b/src/models/rumbleSections.ts
@@ -13,6 +13,27 @@ export default class RumbleSectionsModel extends BaseModel<
   constructor() {
     super('rumble_sections');
   }
+
+  public async updateEndTime(
+    endTime: Date,
+    sectionId: number,
+    rumbleId: number
+  ) {
+    console.log(
+      `Attempting to mark rumble (${rumbleId}) active for section ${sectionId}`
+    );
+
+    await this.db
+      .table(this.tableName)
+      .where('sectionId', sectionId)
+      .where('rumbleId', rumbleId)
+      .update({ endTime })
+      .execute();
+
+    console.log(
+      `Successfully marked rumble (${rumbleId}) active for section ${sectionId}`
+    );
+  }
 }
 
 serviceCollection.addTransient(RumbleSectionsModel);

--- a/src/models/rumbles.ts
+++ b/src/models/rumbles.ts
@@ -1,0 +1,12 @@
+import { Service, serviceCollection } from '../../deps.ts';
+import { INewRumble, IRumble } from '../interfaces/rumbles.ts';
+import BaseModel from './baseModel.ts';
+
+@Service()
+export default class RumbleModel extends BaseModel<INewRumble, IRumble> {
+  constructor() {
+    super('rumbles');
+  }
+}
+
+serviceCollection.addTransient(RumbleModel);

--- a/src/services/cleverService.ts
+++ b/src/services/cleverService.ts
@@ -11,7 +11,9 @@ import {
   CleverAuthResponseType,
   IAuthResponse,
   ICleverEnumData,
+  ISelectOption,
 } from '../interfaces/apiResponses.ts';
+import { GradeType } from '../interfaces/enumGrades.ts';
 import { Roles } from '../interfaces/roles.ts';
 import { SSOLookups } from '../interfaces/ssoLookups.ts';
 import { IOAuthUser } from '../interfaces/users.ts';
@@ -194,24 +196,22 @@ export default class CleverService extends BaseService {
   }
 
   public async getEnumData(): Promise<ICleverEnumData> {
+    const enumMap = (item: Record<string, string>): ISelectOption => {
+      const itemId = Object.keys(item)[0];
+      return { value: itemId, label: item[itemId] };
+    };
     try {
+      // Get and parse the database results for grade enums
       const gradeList = (await this.db.table('enum_grades').execute()) as {
         [key: string]: string;
       }[];
+      const grades = gradeList.map(enumMap);
 
-      const grades = gradeList.map((g) => {
-        const gradeId = Object.keys(g)[0];
-        return { gradeId, value: g[gradeId] };
-      });
-
+      // and for subject enums
       const subjectList = (await this.db.table('enum_subjects').execute()) as {
         [key: string]: string;
       }[];
-
-      const subjects = subjectList.map((s) => {
-        const subjectId = Object.keys(s)[0];
-        return { subjectId, value: s[subjectId] };
-      });
+      const subjects = subjectList.map(enumMap);
 
       return { grades, subjects };
     } catch (err) {

--- a/src/services/cleverService.ts
+++ b/src/services/cleverService.ts
@@ -259,6 +259,40 @@ export default class CleverService extends BaseService {
     }
   }
 
+  public async addChildToSection(
+    joinCode: string,
+    sectionId: number,
+    studentId: number
+  ) {
+    try {
+      // Get the section with the given id
+      const section = await this.sectionModel.get(
+        { id: sectionId },
+        { first: true }
+      );
+      // Handle nonexistent section
+      if (!section) {
+        throw createError(404, 'Invalid section ID');
+      }
+      // Handle incorrect join code
+      if (joinCode !== section.joinCode) {
+        throw createError(401, 'Join code is invalid');
+      }
+
+      // Connect the student user to the section
+      await this.studentModel.add({
+        gradeId: section.gradeId,
+        sectionId: section.id,
+        userId: studentId,
+      });
+
+      return section;
+    } catch (err) {
+      this.logger.error(err);
+      throw err;
+    }
+  }
+
   private generateJoinCode(section: Omit<INewSection, 'joinCode'>) {
     try {
       this.logger.debug(

--- a/src/services/rumble.ts
+++ b/src/services/rumble.ts
@@ -1,0 +1,146 @@
+import {
+  Service,
+  Inject,
+  serviceCollection,
+  createError,
+  v5,
+} from '../../deps.ts';
+import env from '../config/env.ts';
+import { ISection, ISectionPostBody } from '../interfaces/cleverSections.ts';
+import { IRumble, IRumblePostBody } from '../interfaces/rumbles.ts';
+import CleverSectionModel from '../models/cleverSections.ts';
+import CleverStudentModel from '../models/cleverStudents.ts';
+import CleverTeacherModel from '../models/cleverTeachers.ts';
+import RumbleModel from '../models/rumbles.ts';
+import RumbleSectionsModel from '../models/rumbleSections.ts';
+import UserModel from '../models/users.ts';
+import BaseService from './baseService.ts';
+
+@Service()
+export default class RumbleService extends BaseService {
+  constructor(
+    @Inject(UserModel) private userModel: UserModel,
+    @Inject(RumbleModel) private rumbleModel: RumbleModel,
+    @Inject(CleverTeacherModel) private teacherModel: CleverTeacherModel,
+    @Inject(RumbleSectionsModel) private rumbleSections: RumbleSectionsModel,
+    @Inject(CleverStudentModel) private studentModel: CleverStudentModel,
+    @Inject(CleverSectionModel) private sectionModel: CleverSectionModel
+  ) {
+    super();
+  }
+
+  public async createSection(body: ISectionPostBody, teacherId: number) {
+    try {
+      this.logger.debug(
+        `Attempting to add section '${body.name}' for teacher with id ${teacherId}`
+      );
+
+      let section: ISection | undefined;
+      await this.db.transaction(async () => {
+        const joinCode = this.generateJoinCode(body.name);
+        // Transactions mantain data integrity when creaing multiple rows
+        const [res] = await this.sectionModel.add({
+          ...body,
+          joinCode,
+          active: true,
+        });
+
+        await this.teacherModel.add({
+          primary: true,
+          sectionId: res.id,
+          userId: teacherId,
+        });
+
+        section = res;
+      });
+      if (section) return section;
+      else throw createError(400, 'Could not create section');
+    } catch (err) {
+      this.logger.error(err);
+      throw err;
+    }
+  }
+
+  public async addChildToSection(
+    joinCode: string,
+    sectionId: number,
+    studentId: number
+  ) {
+    try {
+      // Get the section with the given id
+      const section = await this.sectionModel.get(
+        { id: sectionId },
+        { first: true }
+      );
+      // Handle nonexistent section
+      if (!section) {
+        throw createError(404, 'Invalid section ID');
+      }
+      // Handle incorrect join code
+      if (joinCode !== section.joinCode) {
+        throw createError(401, 'Join code is invalid');
+      }
+
+      // Connect the student user to the section
+      await this.studentModel.add({
+        gradeId: section.gradeId,
+        sectionId: section.id,
+        userId: studentId,
+      });
+
+      return section;
+    } catch (err) {
+      this.logger.error(err);
+      throw err;
+    }
+  }
+
+  public async createGameInstance(body: IRumblePostBody, sectionId: number) {
+    try {
+      let rumble: IRumble | undefined;
+      await this.db.transaction(async () => {
+        const joinCode = this.generateJoinCode(
+          `${body.numMinutes}-${body.promptId}`
+        );
+        const [res] = await this.rumbleModel.add({
+          joinCode,
+          canJoin: false,
+          maxSections: 1,
+          numMinutes: body.numMinutes,
+          promptId: body.promptId,
+        });
+
+        await this.rumbleSections.add({
+          rumbleId: res.id,
+          sectionId,
+        });
+
+        rumble = res;
+      });
+      return rumble;
+    } catch (err) {
+      this.logger.error(err);
+      throw err;
+    }
+  }
+
+  private generateJoinCode(key: string) {
+    try {
+      this.logger.debug(`Generating join code with key: '${key}'`);
+
+      const joinCode = v5.generate({
+        namespace: env.UUID_NAMESPACE,
+        value: `${key}-${Date.now()}`,
+      }) as string;
+
+      this.logger.debug(`Join code generated for key: '${key}'`);
+
+      return joinCode;
+    } catch (err) {
+      this.logger.error(err);
+      throw err;
+    }
+  }
+}
+
+serviceCollection.addTransient(RumbleService);


### PR DESCRIPTION
# Game Instances

This branch will have changes that allow teachers to create a `rumble` as well as `start` the rumble timer.

> Note: Run `yarn reset` and `yarn reset:test` after this, as the database has changed slightly

## Endpoints

### `POST /api/rumble/teachers/:teacherId/sections/:sectionId/rumbles`

This endpoint creates a new game instance and connects that instance to a given section. It expects the following body:

`{ numMinutes: number; promptId: number; }`

### `PUT /api/rumble/teachers/:teacherId/sections/:sectionId/rumbles/:rumbleId/start`

This endpoint marks the given rumble as active for the specified section. It expects no body and returns a time string.

## Other Change

Also updated the `GET /api/rumble/data` endpoint with the correct response type to work with Victor's new `Select` component.
