### PR TITLE
Refactored the way section get endpoints work for more consistency.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,9 @@
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+  },
   "deno.import_intellisense_origins": {
     "https://deno.land": true
   },

--- a/src/api/routes/rumble/students.ts
+++ b/src/api/routes/rumble/students.ts
@@ -1,13 +1,13 @@
-import { Router, IRouter, log, serviceCollection } from '../../../../deps.ts';
+import { IRouter, log, Router, serviceCollection } from '../../../../deps.ts';
 import { Roles } from '../../../interfaces/roles.ts';
-import CleverStudentModel from '../../../models/cleverStudents.ts';
+import RumbleService from '../../../services/rumble.ts';
 import authHandler from '../../middlewares/authHandler.ts';
 
 const route = Router();
 
 export default (app: IRouter) => {
   const logger: log.Logger = serviceCollection.get('logger');
-  const studentModelInstance = serviceCollection.get(CleverStudentModel);
+  const rumbleServiceInstance = serviceCollection.get(RumbleService);
   app.use('/students', route);
 
   // GET /students/:studentId/sections returns ISection[]
@@ -16,9 +16,7 @@ export default (app: IRouter) => {
     authHandler({ roles: [Roles.admin, Roles.user] }),
     async (req, res) => {
       try {
-        const sections = await studentModelInstance.getSectionsById(
-          parseInt(req.params.studentId, 10)
-        );
+        const sections = await rumbleServiceInstance.getSections(req.body.user);
         res.setStatus(200).json(sections);
       } catch (err) {
         logger.error(err);

--- a/src/api/routes/rumble/teachers.ts
+++ b/src/api/routes/rumble/teachers.ts
@@ -1,19 +1,17 @@
 import {
-  Router,
   IRouter,
-  log,
-  serviceCollection,
-  required,
-  isString,
   isNumber,
+  isString,
+  log,
   minNumber,
-  validateObject,
+  required,
+  Router,
+  serviceCollection,
   validateArray,
+  validateObject,
 } from '../../../../deps.ts';
 import { INewSection } from '../../../interfaces/cleverSections.ts';
 import { Roles } from '../../../interfaces/roles.ts';
-import { IRumblePostBody } from '../../../interfaces/rumbles.ts';
-import CleverTeacherModel from '../../../models/cleverTeachers.ts';
 import RumbleService from '../../../services/rumble.ts';
 import authHandler from '../../middlewares/authHandler.ts';
 import validate from '../../middlewares/validate.ts';
@@ -31,10 +29,7 @@ export default (app: IRouter) => {
     authHandler({ roles: [Roles.admin, Roles.teacher] }),
     async (req, res) => {
       try {
-        const teacherModelInstance = serviceCollection.get(CleverTeacherModel);
-        const sections = await teacherModelInstance.getSectionsById(
-          parseInt(req.params.teacherId, 10)
-        );
+        const sections = await rumbleServiceInstance.getSections(req.body.user);
         res.setStatus(200).json(sections);
       } catch (err) {
         logger.error(err);

--- a/src/services/cleverService.ts
+++ b/src/services/cleverService.ts
@@ -13,7 +13,7 @@ import {
   ICleverEnumData,
   ISelectOption,
 } from '../interfaces/apiResponses.ts';
-import { ISection, ISectionWithRumbles } from '../interfaces/cleverSections.ts';
+import { ISectionWithRumbles } from '../interfaces/cleverSections.ts';
 import { Roles } from '../interfaces/roles.ts';
 import { SSOLookups } from '../interfaces/ssoLookups.ts';
 import { IOAuthUser, IUser } from '../interfaces/users.ts';
@@ -206,24 +206,10 @@ export default class CleverService extends BaseService {
   ): Promise<{ enumData: ICleverEnumData; sections: ISectionWithRumbles[] }> {
     try {
       const enumData = await this.getEnumData();
-
-      let sections: ISection[];
-      console.log({ user });
-      if (user.roleId === Roles.user) {
-        sections = await this.studentModel.getSectionsById(user.id);
-      } else if (user.roleId === Roles.teacher) {
-        sections = await this.teacherModel.getSectionsById(user.id);
-      } else {
-        throw createError(401, 'Invalid user type');
-      }
-
-      await this.rumbleService.getActiveRumblesForSections(
-        sections as ISectionWithRumbles[]
-      );
-
+      const sections = await this.rumbleService.getSections(user);
       return {
         enumData,
-        sections: sections as ISectionWithRumbles[],
+        sections: sections,
       };
     } catch (err) {
       this.logger.error(err);

--- a/src/services/cleverService.ts
+++ b/src/services/cleverService.ts
@@ -1,11 +1,11 @@
 import {
-  Service,
-  serviceCollection,
-  Inject,
   CleverClient,
   createError,
   ICleverStudent,
   ICleverTeacher,
+  Inject,
+  Service,
+  serviceCollection,
 } from '../../deps.ts';
 import {
   CleverAuthResponseType,
@@ -15,23 +15,22 @@ import {
 } from '../interfaces/apiResponses.ts';
 import { ISection, ISectionWithRumbles } from '../interfaces/cleverSections.ts';
 import { Roles } from '../interfaces/roles.ts';
-import { IRumble } from '../interfaces/rumbles.ts';
 import { SSOLookups } from '../interfaces/ssoLookups.ts';
 import { IOAuthUser, IUser } from '../interfaces/users.ts';
 import CleverStudentModel from '../models/cleverStudents.ts';
 import CleverTeacherModel from '../models/cleverTeachers.ts';
-import RumbleModel from '../models/rumbles.ts';
 import SSOLookupModel from '../models/ssoLookups.ts';
 import UserModel from '../models/users.ts';
 import AuthService from './auth.ts';
 import BaseService from './baseService.ts';
+import RumbleService from './rumble.ts';
 
 @Service()
 export default class CleverService extends BaseService {
   constructor(
     @Inject('clever') private clever: CleverClient,
     @Inject(UserModel) private userModel: UserModel,
-    @Inject(RumbleModel) private rumbleModel: RumbleModel,
+    @Inject(RumbleService) private rumbleService: RumbleService,
     @Inject(AuthService) private authService: AuthService,
     @Inject(SSOLookupModel) private ssoModel: SSOLookupModel,
     @Inject(CleverTeacherModel) private teacherModel: CleverTeacherModel,
@@ -218,26 +217,14 @@ export default class CleverService extends BaseService {
         throw createError(401, 'Invalid user type');
       }
 
-      await this.getActiveRumblesForSections(sections as ISectionWithRumbles[]);
+      await this.rumbleService.getActiveRumblesForSections(
+        sections as ISectionWithRumbles[]
+      );
 
       return {
         enumData,
         sections: sections as ISectionWithRumbles[],
       };
-    } catch (err) {
-      this.logger.error(err);
-      throw err;
-    }
-  }
-
-  private async getActiveRumblesForSections(sections: ISectionWithRumbles[]) {
-    try {
-      for await (const section of sections) {
-        const rumbleArray = await this.rumbleModel.getActiveRumblesBySectionId(
-          section.id
-        );
-        section.rumbles = rumbleArray;
-      }
     } catch (err) {
       this.logger.error(err);
       throw err;

--- a/src/services/rumble.ts
+++ b/src/services/rumble.ts
@@ -1,42 +1,76 @@
 import {
-  Service,
-  Inject,
-  serviceCollection,
   createError,
-  v5,
+  Inject,
   moment,
+  Service,
+  serviceCollection,
+  v5,
 } from '../../deps.ts';
-import sections from '../api/routes/rumble/sections.ts';
 import env from '../config/env.ts';
 import {
   ISection,
   ISectionPostBody,
   ISectionWithRumbles,
 } from '../interfaces/cleverSections.ts';
+import { Roles } from '../interfaces/roles.ts';
 import {
-  IRumble,
   IRumblePostBody,
   IRumbleWithSectionInfo,
 } from '../interfaces/rumbles.ts';
+import { IUser } from '../interfaces/users.ts';
 import CleverSectionModel from '../models/cleverSections.ts';
 import CleverStudentModel from '../models/cleverStudents.ts';
 import CleverTeacherModel from '../models/cleverTeachers.ts';
 import RumbleModel from '../models/rumbles.ts';
 import RumbleSectionsModel from '../models/rumbleSections.ts';
-import UserModel from '../models/users.ts';
 import BaseService from './baseService.ts';
 
 @Service()
 export default class RumbleService extends BaseService {
   constructor(
-    @Inject(UserModel) private userModel: UserModel,
     @Inject(RumbleModel) private rumbleModel: RumbleModel,
     @Inject(CleverTeacherModel) private teacherModel: CleverTeacherModel,
-    @Inject(RumbleSectionsModel) private rumbleSections: RumbleSectionsModel,
     @Inject(CleverStudentModel) private studentModel: CleverStudentModel,
-    @Inject(CleverSectionModel) private sectionModel: CleverSectionModel
+    @Inject(CleverSectionModel) private sectionModel: CleverSectionModel,
+    @Inject(RumbleSectionsModel) private rumbleSections: RumbleSectionsModel
   ) {
     super();
+  }
+
+  public async getSections(user: IUser) {
+    try {
+      this.logger.debug(`Getting sections for user ${user.id}`);
+
+      let sections: ISection[];
+      if (user.roleId === Roles.teacher) {
+        sections = await this.teacherModel.getSectionsById(user.id);
+      } else if (user.roleId === Roles.user) {
+        sections = await this.studentModel.getSectionsById(user.id);
+      } else {
+        throw createError(401, 'Invalid user type!');
+      }
+
+      await this.getActiveRumblesForSections(sections as ISectionWithRumbles[]);
+
+      return sections;
+    } catch (err) {
+      this.logger.error(err);
+      throw err;
+    }
+  }
+
+  public async getActiveRumblesForSections(sections: ISectionWithRumbles[]) {
+    try {
+      for await (const section of sections) {
+        const rumbleArray = await this.rumbleModel.getActiveRumblesBySectionId(
+          section.id
+        );
+        section.rumbles = rumbleArray;
+      }
+    } catch (err) {
+      this.logger.error(err);
+      throw err;
+    }
   }
 
   public async createSection(body: ISectionPostBody, teacherId: number) {

--- a/src/services/rumble.ts
+++ b/src/services/rumble.ts
@@ -52,7 +52,7 @@ export default class RumbleService extends BaseService {
 
       await this.getActiveRumblesForSections(sections as ISectionWithRumbles[]);
 
-      return sections;
+      return sections as ISectionWithRumbles[];
     } catch (err) {
       this.logger.error(err);
       throw err;


### PR DESCRIPTION
Moved section get queries into the rumble service and combined student and teacher into the same query. Moved all logic for section getting out of the clever service class. This should allow more consistent handling of student and teacher data.