### PR TITLE
GET prompt by ID now allows type users

### DIFF
--- a/src/api/routes/prompts.ts
+++ b/src/api/routes/prompts.ts
@@ -101,7 +101,7 @@ export default (app: IRouter) => {
   // GET /:id
   route.get(
     '/:id',
-    authHandler({ roles: [Roles.teacher, Roles.admin] }),
+    authHandler({ roles: [Roles.teacher, Roles.admin, Roles.user] }),
     validate({ id: [required, isNumber] }, 'params'),
     async (req: Request, res: Response, next: NextFunction) => {
       try {

--- a/src/api/routes/submissions.ts
+++ b/src/api/routes/submissions.ts
@@ -1,17 +1,17 @@
 import {
-  Router,
   IRouter,
-  Request,
-  Response,
+  isArray,
+  isNumber,
+  isString,
   log,
+  minNumber,
+  Request,
+  required,
+  Response,
+  Router,
   serviceCollection,
   validateArray,
   validateObject,
-  isString,
-  required,
-  isNumber,
-  minNumber,
-  isArray,
 } from '../../../deps.ts';
 import { Roles } from '../../interfaces/roles.ts';
 import { INewSubmission } from '../../interfaces/submissions.ts';
@@ -28,10 +28,11 @@ export default (app: IRouter) => {
   const subServiceInstance = serviceCollection.get(SubmissionService);
   app.use(['/submit', '/submission', '/submissions'], route);
 
-  // POST /
+  // POST / ?sourceId
   route.post(
     '/',
     authHandler(),
+    validate({ sourceId: [required] }, 'query'),
     // This will ensure there is only one item in the story field before upload
     validate<INewSubmission>({
       story: validateArray(

--- a/src/api/routes/submissions.ts
+++ b/src/api/routes/submissions.ts
@@ -28,11 +28,12 @@ export default (app: IRouter) => {
   const subServiceInstance = serviceCollection.get(SubmissionService);
   app.use(['/submit', '/submission', '/submissions'], route);
 
+  // api/submissions/
+
   // POST / ?sourceId
   route.post(
     '/',
     authHandler(),
-    validate({ sourceId: [required] }, 'query'),
     // This will ensure there is only one item in the story field before upload
     validate<INewSubmission>({
       story: validateArray(


### PR DESCRIPTION
# Update to Prompt Routes

`GET` a prompt by id now allows type users to access endpoint. 
This update is to designed to allow users to open any Rumble Instance and view that Rumbles prompt. 
Being that Teachers will be making custom prompts we need to make sure we are presenting the proper prompt for every Rumble Instance.