### PR TITLE
Bugfix/put-request-update-for-feedback-submission

### DIFF
--- a/src/api/routes/rumble/feedback.ts
+++ b/src/api/routes/rumble/feedback.ts
@@ -6,6 +6,8 @@ import {
   serviceCollection,
 } from '../../../../deps.ts';
 import FeedbackService from '../../../services/feedback.ts';
+import RumbleService from '../../../services/rumble.ts';
+import authHandler from '../../middlewares/authHandler.ts';
 import validate from '../../middlewares/validate.ts';
 
 const route = Router();
@@ -13,6 +15,8 @@ const route = Router();
 export default (app: IRouter) => {
   const logger: log.Logger = serviceCollection.get('logger');
   const feedbackServiceInstance = serviceCollection.get(FeedbackService);
+  const rumbleServiceInstance = serviceCollection.get(RumbleService);
+
   app.use('/feedback', route);
 
   // /feedback/complete?studentId=:studentId&rumbleId=:rumbleId
@@ -41,6 +45,16 @@ export default (app: IRouter) => {
       }
     }
   );
+
+  route.put('/', authHandler(), async (req, res) => {
+    try {
+      await rumbleServiceInstance.addScoresToFeedback(req.body);
+      res.setStatus(204).end();
+    } catch (err) {
+      logger.error(err);
+      throw err;
+    }
+  });
 
   console.log('Feedback router loaded.');
 };

--- a/src/api/routes/submissions.ts
+++ b/src/api/routes/submissions.ts
@@ -17,7 +17,6 @@ import { Roles } from '../../interfaces/roles.ts';
 import { INewSubmission } from '../../interfaces/submissions.ts';
 import RumbleFeedbackModel from '../../models/rumbleFeedback.ts';
 import SubmissionModel from '../../models/submissions.ts';
-import RumbleService from '../../services/rumble.ts';
 import SubmissionService from '../../services/submission.ts';
 import authHandler from '../middlewares/authHandler.ts';
 import upload from '../middlewares/upload.ts';
@@ -29,7 +28,7 @@ export default (app: IRouter) => {
   const logger: log.Logger = serviceCollection.get('logger');
   const subServiceInstance = serviceCollection.get(SubmissionService);
   const feedbackModelInstance = serviceCollection.get(RumbleFeedbackModel);
-  const rumbleServiceInstance = serviceCollection.get(RumbleService);
+
   app.use(['/submit', '/submission', '/submissions'], route);
 
   // api/submissions/
@@ -221,20 +220,6 @@ export default (app: IRouter) => {
           parseInt(req.params.id, 10),
           parseInt(req.params.flagId, 10)
         );
-        res.setStatus(204).end();
-      } catch (err) {
-        logger.error(err);
-        throw err;
-      }
-    }
-  );
-
-  route.put(
-    '/:submissionId/feedback',
-    authHandler(),
-    async (req: Request, res: Response) => {
-      try {
-        await rumbleServiceInstance.addScoresToFeedback(req.body);
         res.setStatus(204).end();
       } catch (err) {
         logger.error(err);


### PR DESCRIPTION
Moves PUT endpoint for submitting feedback from `submissions.ts` to `feedback.ts`. Updates the endpoint route to remove `SubmissionId` which was unnecessary/didn't make sense.